### PR TITLE
Update jquery.timepicker.js to version 1.3.8.

### DIFF
--- a/vendor/assets/javascripts/jquery.timepicker.js
+++ b/vendor/assets/javascripts/jquery.timepicker.js
@@ -431,7 +431,7 @@ requires jQuery 1.7+
 			}
 
 			if ((settings.minTime !== null || settings.durationTime !== null) && settings.showDuration) {
-				var durationString = _int2duration(i - durStart);
+				var durationString = _int2duration(i - durStart, settings.step);
 				if (settings.useSelect) {
 					row.text(row.text()+' ('+durationString+')');
 				} else {
@@ -903,7 +903,7 @@ requires jQuery 1.7+
 		return true;
 	}
 
-	function _int2duration(seconds)
+	function _int2duration(seconds, step)
 	{
 		var minutes = Math.round(seconds/60),
 			duration = [],


### PR DESCRIPTION
Hi, the file `vendor/assets/javascripts/jquery.timepicker.js` had not been correctly updated to the code present in https://github.com/jonthornton/jquery-timepicker/blob/1.3.8/jquery.timepicker.js. I was suffering from [this error](https://github.com/jonthornton/jquery-timepicker/pull/246), so I updated it.
